### PR TITLE
send empty room message on subscribe to empty topic

### DIFF
--- a/bin/server.js
+++ b/bin/server.js
@@ -91,9 +91,14 @@ const onconnection = conn => {
             if (typeof topicName === 'string') {
               // add conn to topic
               const topic = map.setIfUndefined(topics, topicName, () => new Set())
+              const prev_size = topic.size;
               topic.add(conn)
               // add topic to conn
               subscribedTopics.add(topicName)
+
+              const empty = prev_size == 0 && topic.size == 1;
+              if (empty)
+                send(conn, { type: "empty" });
             }
           })
           break


### PR DESCRIPTION
Notion Ticket: https://www.notion.so/strivemath/Bug-loading-code-with-project-links-if-live-ID-is-present-59bdd5ab7a664288884d6e1a76d95b52

when a new connection subscribes to a topic (room) and the topic has no other subscribers it will send an 'empty room' message to that connection.